### PR TITLE
Simplify Python requirements

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,17 +11,17 @@ source:
   sha256: 4d1178a03de549ef95e01fc3328fa966e586d17e1654831f4d74aeea07e30348
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
   host:
     - pip
-    - python =2.7|>=3.4
+    - python >=2.7
   run:
     - certifi
-    - python =2.7|>=3.4
+    - python >=2.7
     - python-dateutil
     - six >=1.10
     - urllib3 >=1.15


### PR DESCRIPTION
There is no Python >2.7,<3.4 in conda-forge, so it seems that this condition can be relaxed.

I am not sure if guarding against 2.6 is necessary at all these days so maybe the pin can be dropped altogether.

Note that the old selector gets constantly rewritten by the repodata patches, see https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/317#issuecomment-1259168608

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
